### PR TITLE
Use incremental Z3 solver for runs w/o generalization

### DIFF
--- a/pric3/pric3_solver.py
+++ b/pric3/pric3_solver.py
@@ -29,14 +29,14 @@ class PrIC3Solver:
 
     def add_new_solver(self):
         #solver = OneshotSolver(SolverFor("QF_NRA"))
-        solver = OneshotSolver()
+        solver = OneshotSolver() if self.settings.generalize else Solver()
         self.initialize_solver(solver)
         self.solvers.append(solver)
         #print(solver.sexpr())
 
     def initialize_f0(self):
         #solver = OneshotSolver(SolverFor("QF_NRA"))
-        solver = OneshotSolver()
+        solver = OneshotSolver() if self.settings.generalize else Solver()
         self.solvers.append(solver)
 
         self.initialize_solver(solver)


### PR DESCRIPTION
This reverses the regression for runs w/o generalization introduced by e4a87c0ef217548e1767bea2556c351d8ab2eaaa.